### PR TITLE
Remove remote-debugging switch from shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ channel will be used.
 ## Shims and Command Line Flags
 
 This buildpack installs shims that always add `--headless`, `--disable-gpu`, 
-`--no-sandbox`, and `--remote-debugging-port=9222` to any `google-chrome` 
+and `--no-sandbox` to any `google-chrome`
 command as you'll have trouble running Chrome on a Heroku dyno otherwise.
 
 You'll have two of these shims on your path: `google-chrome` and

--- a/bin/compile
+++ b/bin/compile
@@ -138,7 +138,7 @@ topic "Creating google-chrome shims"
 rm $SHIM
 cat <<EOF >$SHIM
 #!/usr/bin/env bash
-exec $BIN --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 \$@
+exec $BIN --headless --no-sandbox --disable-gpu \$@
 EOF
 chmod +x $SHIM
 cp $SHIM $BIN_DIR/google-chrome


### PR DESCRIPTION
This switch prevents printing to PDF.